### PR TITLE
Add support for Azure-hosted Mistral models

### DIFF
--- a/dotnet/src/Connectors/Connectors.Mistral/ChatCompletion/MistralAIChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.Mistral/ChatCompletion/MistralAIChatCompletionService.cs
@@ -23,15 +23,17 @@ public sealed class MistralAIChatCompletionService : IChatCompletionService, ITe
     /// <param name="modelId">Model name</param>
     /// <param name="apiKey">Mistral API Key</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
+    /// <param name="endpoint">Custom endpoint for the Mistral service.</param>
     public MistralAIChatCompletionService(
         string modelId,
         string apiKey,
-         HttpClient? httpClient = null)
+        HttpClient? httpClient = null,
+        string? endpoint = null)
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(apiKey);
 
-        this._core = new MistralClientCore(modelId, apiKey, httpClient);
+        this._core = new MistralClientCore(modelId, apiKey, endpoint, httpClient);
 
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }

--- a/dotnet/src/Connectors/Connectors.Mistral/MistralAPI/MistralClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.Mistral/MistralAPI/MistralClientCore.cs
@@ -53,7 +53,7 @@ internal sealed class MistralClientCore
     {
         this._apiKey = apiKey;
         this._httpClient = HttpClientProvider.GetHttpClient(httpClient);
-        this._endpoint = endpoint ?? "https://api.mistral.ai/v1";
+        this._endpoint = endpoint ?? "https://api.mistral.ai";
         this.DeploymentOrModelName = modelName;
         this.Logger = logger ?? NullLogger.Instance;
     }
@@ -255,7 +255,7 @@ internal sealed class MistralClientCore
         string requestJson = JsonSerializer.Serialize(request);
         using (var content = new StringContent(requestJson, Encoding.UTF8, "application/json"))
         {
-            string url = $"{this._endpoint}/chat/completions";
+            string url = $"{this._endpoint}/v1/chat/completions";
             var response = await this.CallMistralAuthedAsync(url, content).ConfigureAwait(false);
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
@@ -325,7 +325,7 @@ internal sealed class MistralClientCore
 
         using (var content = new StringContent(JsonSerializer.Serialize(embeddingRequest), Encoding.UTF8, "application/json"))
         {
-            string url = $"{this._endpoint}/embeddings";
+            string url = $"{this._endpoint}/v1/embeddings";
             var response = await this.CallMistralAuthedAsync(url, content).ConfigureAwait(false);
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             if (string.IsNullOrEmpty(responseContent))
@@ -351,7 +351,7 @@ internal sealed class MistralClientCore
         string requestJson = JsonSerializer.Serialize(request);
         using (var content = new StringContent(requestJson, Encoding.UTF8, "application/json"))
         {
-            string url = $"{this._endpoint}/chat/completions";
+            string url = $"{this._endpoint}/v1/chat/completions";
             var response = await this.CallMistralAuthedAsync(url, content).ConfigureAwait(false);
             return response;
         }

--- a/dotnet/src/Connectors/Connectors.Mistral/MistralAPI/MistralClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.Mistral/MistralAPI/MistralClientCore.cs
@@ -49,12 +49,17 @@ internal sealed class MistralClientCore
     /// <summary>Tracking <see cref="AsyncLocal{Int32}"/> for <see cref="MaxInflightAutoInvokes"/>.</summary>
     private static readonly AsyncLocal<int> s_inflightAutoInvokes = new();
 
-    internal MistralClientCore(string modelName, string apiKey, HttpClient? httpClient = null, ILogger? logger = null)
+    internal MistralClientCore(string modelName, string apiKey, string? endpoint = null, HttpClient? httpClient = null, ILogger? logger = null)
     {
         this._apiKey = apiKey;
         this._httpClient = HttpClientProvider.GetHttpClient(httpClient);
+        this._endpoint = endpoint ?? "https://api.mistral.ai/v1";
         this.DeploymentOrModelName = modelName;
         this.Logger = logger ?? NullLogger.Instance;
+    }
+
+    internal MistralClientCore(string modelName, string apiKey, HttpClient? httpClient = null, ILogger? logger = null) : this(modelName, apiKey, null, httpClient, logger)
+    {
     }
 
     /// <summary>
@@ -69,6 +74,7 @@ internal sealed class MistralClientCore
 
     private readonly string _apiKey;
     private readonly HttpClient _httpClient;
+    private readonly string _endpoint;
 
     /// <summary>
     /// Storage for AI service attributes.
@@ -249,7 +255,7 @@ internal sealed class MistralClientCore
         string requestJson = JsonSerializer.Serialize(request);
         using (var content = new StringContent(requestJson, Encoding.UTF8, "application/json"))
         {
-            string url = "https://api.mistral.ai/v1/chat/completions";
+            string url = $"{this._endpoint}/chat/completions";
             var response = await this.CallMistralAuthedAsync(url, content).ConfigureAwait(false);
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
@@ -319,7 +325,7 @@ internal sealed class MistralClientCore
 
         using (var content = new StringContent(JsonSerializer.Serialize(embeddingRequest), Encoding.UTF8, "application/json"))
         {
-            string url = "https://api.mistral.ai/v1/embeddings";
+            string url = $"{this._endpoint}/embeddings";
             var response = await this.CallMistralAuthedAsync(url, content).ConfigureAwait(false);
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             if (string.IsNullOrEmpty(responseContent))
@@ -345,7 +351,7 @@ internal sealed class MistralClientCore
         string requestJson = JsonSerializer.Serialize(request);
         using (var content = new StringContent(requestJson, Encoding.UTF8, "application/json"))
         {
-            string url = "https://api.mistral.ai/v1/chat/completions";
+            string url = $"{this._endpoint}/chat/completions";
             var response = await this.CallMistralAuthedAsync(url, content).ConfigureAwait(false);
             return response;
         }

--- a/dotnet/src/Connectors/Connectors.Mistral/MistralServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Mistral/MistralServiceCollectionExtensions.cs
@@ -115,7 +115,7 @@ public static class MistralServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds the Mistral chat completion service to the list.
+    /// Adds the Mistral text completion service to the list.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
     /// <param name="modelId">Mistral model name</param>
@@ -142,6 +142,69 @@ public static class MistralServiceCollectionExtensions
 
         return services;
     }
+
+    #region Azure Mistral
+    /// <summary>
+    /// Adds the Azure-hosted Mistral chat completion service to the list.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="endpoint">Mistral endpoint</param>
+    /// <param name="modelId">Mistral model name</param>
+    /// <param name="apiKey">Mistral API key</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    public static IServiceCollection AddAzureMistralChatCompletion(
+        this IServiceCollection services,
+        string endpoint,
+        string modelId,
+        string apiKey,
+        string? serviceId = null)
+    {
+        Verify.NotNull(services);
+        Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        Func<IServiceProvider, object?, MistralAIChatCompletionService> factory = (serviceProvider, _) =>
+        {
+            return new(modelId,
+               apiKey, HttpClientProvider.GetHttpClient(serviceProvider), endpoint);
+        };
+
+        services.AddKeyedSingleton<IChatCompletionService>(serviceId, factory);
+
+        return services;
+    }
+    /// <summary>
+    /// Adds the Azure-hosted Mistral text completion service to the list.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="endpoint">Mistral endpoint</param>
+    /// <param name="modelId">Mistral model name</param>
+    /// <param name="apiKey">Mistral API key</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    public static IServiceCollection AddAzureMistralTextCompletion(
+        this IServiceCollection services,
+        string endpoint,
+        string modelId,
+        string apiKey,
+        string? serviceId = null)
+    {
+        Verify.NotNull(services);
+        Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        Func<IServiceProvider, object?, MistralAIChatCompletionService> factory = (serviceProvider, _) =>
+        {
+            return new(modelId,
+               apiKey, HttpClientProvider.GetHttpClient(serviceProvider), endpoint);
+        };
+
+        services.AddKeyedSingleton<IChatCompletionService>(serviceId, factory);
+
+        return services;
+    }
+    #endregion
     #endregion
 
     #region Text Embedding

--- a/dotnet/src/Connectors/Connectors.Mistral/MistralServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Mistral/MistralServiceCollectionExtensions.cs
@@ -147,6 +147,40 @@ public static class MistralServiceCollectionExtensions
     /// <summary>
     /// Adds the Azure-hosted Mistral chat completion service to the list.
     /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="endpoint">Mistral endpoint</param>
+    /// <param name="apiKey">Azure Mistral API key, see https://learn.microsoft.com/azure/cognitive-services/Mistral/quickstart</param>
+    /// <param name="modelId">Model identifier</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    public static IKernelBuilder AddAzureMistralChatCompletion(
+        this IKernelBuilder builder,
+        string endpoint,
+        string apiKey,
+        string modelId,
+        string? serviceId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        Func<IServiceProvider, object?, MistralAIChatCompletionService> factory = (serviceProvider, _) =>
+        {
+            return new(modelId,
+               apiKey, HttpClientProvider.GetHttpClient(httpClient, serviceProvider), endpoint);
+        };
+
+        builder.Services.AddKeyedSingleton<IChatCompletionService>(serviceId, factory);
+        builder.Services.AddKeyedSingleton<ITextGenerationService>(serviceId, factory);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the Azure-hosted Mistral chat completion service to the list.
+    /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
     /// <param name="endpoint">Mistral endpoint</param>
     /// <param name="modelId">Mistral model name</param>
@@ -173,6 +207,40 @@ public static class MistralServiceCollectionExtensions
         services.AddKeyedSingleton<IChatCompletionService>(serviceId, factory);
 
         return services;
+    }
+
+    /// <summary>
+    /// Adds the Azure-hosted Mistral text completion service to the list.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="endpoint">Mistral endpoint</param>
+    /// <param name="apiKey">Mistral API key</param>
+    /// <param name="modelId">Model identifier</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    public static IKernelBuilder AddMistralTextCompletion(
+        this IKernelBuilder builder,
+        string endpoint,
+        string apiKey,
+        string modelId,
+        string? serviceId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(modelId);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        Func<IServiceProvider, object?, MistralAIChatCompletionService> factory = (serviceProvider, _) =>
+        {
+            return new(modelId,
+               apiKey, HttpClientProvider.GetHttpClient(httpClient, serviceProvider), endpoint);
+        };
+
+        builder.Services.AddKeyedSingleton<IChatCompletionService>(serviceId, factory);
+        builder.Services.AddKeyedSingleton<ITextGenerationService>(serviceId, factory);
+
+        return builder;
     }
     /// <summary>
     /// Adds the Azure-hosted Mistral text completion service to the list.


### PR DESCRIPTION
### Motivation and Context
The current code is hard coded to the https://api.mistral.ai endpoint. Azure allows you to deploy your own instance of the Mistral model at a dedicated endpoint. This PR allows you to use these models by supplying your own endpoint (e.g. something like https://Mistral-large-fwjfwv-serverless.eastus2.inference.ai.azure.com)

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- New `MistralClientCore` constructor that allows the caller to supply an endpoint. Use the supplied endpoint everywhere that previously used "https://api.mistral.ai"
- New optional `endpoint` argument to `MistralAIChatCompletionService` constructor that gets passed to the `MistralClientCore` constructor
- New `AddAzureMistralTextCompletion()` and `AddAzureMistralChatCompletion()` builders in the service collection extensions that take an endpoint parameter.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
